### PR TITLE
fix: add @commitlint/cli to root devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "yargs": "^17.7.3"
   },
   "devDependencies": {
+    "@commitlint/cli": "^21.2.1",
     "@eslint/js": "^10.0.1",
     "@semantic-release/changelog": "^7.0.0",
     "@semantic-release/exec": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
         specifier: ^17.7.3
         version: 17.7.3
     devDependencies:
+      '@commitlint/cli':
+        specifier: ^21.2.1
+        version: 21.2.1(@types/node@26.1.2)(conventional-commits-parser@7.1.2)(typescript@5.9.3)
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.8.0(jiti@2.7.0))


### PR DESCRIPTION
## Summary

- Adds `@commitlint/cli` as a direct `devDependency` so the husky `commit-msg` hook can resolve `commitlint` from the project root in a fresh clone

Closes #117