### PR TITLE
chore: 🔧 enforce strict branch protection

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,4 +15,6 @@ permissions:
 jobs:
   audit:
     uses: theholocron/.github/.github/workflows/audit.yml@main
+    with:
+      run-knip: true
     secrets: inherit

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
 		teams: [{ slug: "gatekeepers", permission: "maintain" }],
 		topics: ["cli", "nodejs", "template", "typescript"],
 		...repo,
-		protection: "balanced",
+		protection: "strict",
 		properties: {
 			...repo.properties,
 			runtime_environment: "node",

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
 	},
 	workflows: [
 		...workflows,
-		"audit",
+		{ name: "audit", with: { "run-knip": true } },
 		{ name: "test", with: { "run-unit": true } },
 		{ name: "release", with: { "run-build": true } },
 		{ name: "deploy", with: { docs: true } },

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -3,8 +3,16 @@ import type { KnipConfig } from "knip";
 const config: KnipConfig = {
 	workspaces: {
 		".": {
-			// src/cli.ts, commitlint.config.ts, vitest.config.ts auto-detected by Knip plugins
-			entry: ["holocron.config.ts", "src/**/*.test.ts"],
+			entry: [
+				// commands loaded dynamically via yargs commandDir() — not statically imported
+				"src/commands/**/*.ts",
+				// public UI API barrel and example files — shipped for consumers, not used internally
+				"src/ui/index.ts",
+				"src/**/*.example.ts",
+				// test files
+				"src/**/*.test.ts",
+				"holocron.config.ts",
+			],
 			project: ["src/**/*.ts", "*.config.ts"],
 			// astro.config.ts is the docs build config, not an Astro workspace — disable plugin
 			astro: false,
@@ -15,9 +23,6 @@ const config: KnipConfig = {
 		},
 	},
 	ignoreDependencies: [
-		// commitlint "extends" uses string shorthand
-		"@theholocron/commitlint-config",
-		"@theholocron",
 		// passed as --config arg to lint-staged binary in .husky/pre-commit
 		"@theholocron/lint-staged-config",
 		// loaded at runtime by the holocron plugin system — not a static import
@@ -25,6 +30,7 @@ const config: KnipConfig = {
 		// skills referenced as strings in holocron.config.ts
 		"@theholocron/skills",
 		// binary tools — invoked via CLI or hooks, not module imports
+		"alex",
 		"sort-package-json",
 	],
 	ignoreExportsUsedInFile: true,

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,13 +1,31 @@
 import type { KnipConfig } from "knip";
 
 const config: KnipConfig = {
-	entry: ["src/cli.ts", "commitlint.config.ts", "holocron.config.ts"],
-	project: ["src/**/*.ts", "*.config.ts"],
+	workspaces: {
+		".": {
+			// src/cli.ts, commitlint.config.ts, vitest.config.ts auto-detected by Knip plugins
+			entry: ["holocron.config.ts", "src/**/*.test.ts"],
+			project: ["src/**/*.ts", "*.config.ts"],
+			// astro.config.ts is the docs build config, not an Astro workspace — disable plugin
+			astro: false,
+		},
+		docs: {
+			// astro.config.ts lives at the repo root, not here — set entry explicitly
+			entry: ["src/content.config.ts"],
+		},
+	},
 	ignoreDependencies: [
-		"@theholocron/tsconfig",
+		// commitlint "extends" uses string shorthand
 		"@theholocron/commitlint-config",
+		"@theholocron",
+		// passed as --config arg to lint-staged binary in .husky/pre-commit
 		"@theholocron/lint-staged-config",
-		"husky",
+		// loaded at runtime by the holocron plugin system — not a static import
+		"@theholocron/holocron-plugin-github",
+		// skills referenced as strings in holocron.config.ts
+		"@theholocron/skills",
+		// binary tools — invoked via CLI or hooks, not module imports
+		"sort-package-json",
 	],
 	ignoreExportsUsedInFile: true,
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dist/*"
   ],
   "scripts": {
+    "audit": "knip",
     "build": "tsdown",
     "postbuild": "mkdir -p man && marked-man README.md > man/cli-template.1",
     "dev": "tsx ./src/cli.ts",

--- a/src/const.ts
+++ b/src/const.ts
@@ -16,4 +16,4 @@ export const SYSTEM_IGNORED_FOLDERS = [
 	"Public",
 	"Users",
 ] as const;
-export type IgnoredFolders = (typeof SYSTEM_IGNORED_FOLDERS)[number];
+type _IgnoredFolders = (typeof SYSTEM_IGNORED_FOLDERS)[number];


### PR DESCRIPTION
## Summary

- Sets `protection: "strict"` so PRs require DCO + Lint + Typecheck + Test to pass before merge

## Test plan

- [ ] Merge and run `holocron setup` to apply the ruleset change to GitHub