### PR TITLE
chore: 🔧 apply holocron setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
     groups:
       security-patches:
         applies-to: security-updates
@@ -22,6 +25,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "chore(deps)"
     groups:
       all-actions:
         patterns:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 # AUTO-GENERATED — do not edit directly.
 # Source:  theholocron/holocron · packages/cli/src/commands/setup-workflows.ts
-# Tool:    holocron sync-github
-# Changes: edit source in theholocron/holocron and push to alpha or main.
+# Tool:    holocron setup
+# Changes: run `holocron setup` to regenerate.
 name: Deploy
 
 on: # yamllint disable-line rule:truthy

--- a/holocron.config.ts
+++ b/holocron.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
 		topics: ["cli", "nodejs", "template", "typescript"],
 		...repo,
 		protection: "strict",
+		requiredChecks: ["audit / Knip", "codecov/patch", "codecov/project"],
 		properties: {
 			...repo.properties,
 			runtime_environment: "node",


### PR DESCRIPTION
## Summary

- Applies `holocron setup` output from main after merging the branch protection PR
- Adds commit message prefixes to `dependabot.yml`
- Updates `deploy.yml` tool header to reflect `holocron setup` as the generator

## Test plan

- [ ] Merge