### PR TITLE
fix(deploy): add astro config files to path triggers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,9 @@ on: # yamllint disable-line rule:truthy
     branches: [main]
     paths:
       - docs/**
+      - astro.config.ts
+      - pnpm-workspace.yaml
+      - pnpm-lock.yaml
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Adds `astro.config.ts`, `pnpm-workspace.yaml`, and `pnpm-lock.yaml` to the deploy workflow path triggers so updates to those files (e.g. bumping `@theholocron/astro-config` in the lockfile) automatically trigger a redeploy.

Without this, merging a lockfile-only dependency bump doesn't redeploy the docs site, leaving the old build in place.
